### PR TITLE
Add tpm_tis module

### DIFF
--- a/install/encrypt-tpm
+++ b/install/encrypt-tpm
@@ -4,6 +4,7 @@ build() {
     local mod
 
     add_module "tpm_crb"
+    add_module "tpm_tis"
 
     add_binary "tpm2_unseal"
     add_binary "/usr/lib/libtss2-tcti-device.so"


### PR DESCRIPTION
On some computers you will get the following error without the tpm_tis module:
```
ERROR:tcti:src/tss2-tcti/tcti-device.c:439:Tss2_Tcti_Device_Init() Failed to open device file /dev/tpmrm0: No such file or directory
WARNING:tcti:src/tss2-tcti/tctildr.c:62:tcti_from_init() TCTI init for function 0x7f36914deec0 failed with a000a 
WARNING:tcti:src/tss2-tcti/tctildr.c:92:tcti_from_info() Could not initialize TCTI named: tcti-device 
ERROR:tcti:src/tss2-tcti/tctildr-dl.c:150:tcti_from_file() Could not initialize TCTI file: libtss2-tcti-device.so.0 
ERROR:tcti:src/tss2-tcti/tcti-device.c:439:Tss2_Tcti_Device_Init() Failed to open device file /dev/tpm0: No such file or directory 
WARNING:tcti:src/tss2-tcti/tctildr.c:62:tcti_from_init() TCTI init for function 0x7f36914deec0 failed with a000a 
WARNING:tcti:src/tss2-tcti/tctildr.c:92:tcti_from_info() Could not initialize TCTI named: tcti-device 
ERROR:tcti:src/tss2-tcti/tctildr-dl.c:150:tcti_from_file() Could not initialize TCTI file: libtss2-tcti-device.so.0 
WARNING:tcti:src/tss2-tcti/tctildr.c:62:tcti_from_init() TCTI init for function 0x7f36914df2d0 failed with a000a 
ERROR:tcti:src/tss2-tcti/tctildr-dl.c:248:tctildr_get_default() No standard TCTI could be loaded 
ERROR:tcti:src/tss2-tcti/tctildr.c:418:Tss2_TctiLdr_Initialize_Ex() Failed to instantiate TCTI 
ERROR: Could not load tcti, got: "(null)"
```